### PR TITLE
メッセージ表示の実装

### DIFF
--- a/src/main/java/com/example/demo/controller/MessageController.java
+++ b/src/main/java/com/example/demo/controller/MessageController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import java.io.IOException;
 
+import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -40,7 +41,7 @@ public class MessageController {
 
 		//チャットルーム1件取得
 		MRoom room = roomService.getRoomOne(roomId);
-		
+
 		if (result.hasErrors()) {
 			//NG:メッセージ送信画面にリダイレクト
 			return "redirect:/rooms/{roomId}";
@@ -49,9 +50,15 @@ public class MessageController {
 		log.info(form.toString());
 
 		//画像データをフォームから取得し設定
-		message.setImage(form.getMultiPartFile().getBytes());
+		StringBuffer data = new StringBuffer();
+		String base64 = new String(Base64.encodeBase64(form.getMultiPartFile().getBytes()), "ASCII");
+		data.append("data:image/png;base64, ");
+		data.append(base64);
+		message.setImage(data.toString());
+
 		service.insertMessage(message, form, loginUser, room.getId());
 
 		return "redirect:/rooms/{roomId}";
 	}
+
 }

--- a/src/main/java/com/example/demo/controller/RoomController.java
+++ b/src/main/java/com/example/demo/controller/RoomController.java
@@ -87,40 +87,63 @@ public class RoomController {
 	}
 
 	@GetMapping("/rooms/{roomId}")
-	public String getRoom(Model model, @AuthenticationPrincipal UserDetailServiceImpll loginUser, @PathVariable("roomId") int id, @ModelAttribute("form") MessageForm form) {
-		
+	public String getRoom(Model model, @AuthenticationPrincipal UserDetailServiceImpll loginUser,
+			@PathVariable("roomId") int id, @ModelAttribute("form") MessageForm form) {
+
 		//ログインユーザーの情報を取得
 		String username = loginUser.getUser().getName();
 		int loginUserId = loginUser.getUser().getId();
-		
+
 		model.addAttribute("username", username);
 
 		//ログインユーザーと選択されたユーザーが保有するチャットルームを取得
 		List<MRoom> rooms = roomService.getLoginUserRooms(loginUser);
 		model.addAttribute("rooms", rooms);
-		
+
 		//room_usersテーブルのレコード(1件)取得
 		TRoomUser roomUser = roomUserService.getRoomUserOne(id);
-		
+
 		//room_usersに登録されているログインユーザーのIDを取得
 		int currentUserId = roomUser.getCurrentUserId();
 		//room_usersに登録されているチャットするユーザーのIDを取得
 		int userId = roomUser.getUserId();
-		
+
 		//ログインユーザーとroom_usersのログインユーザーID、またはログインユーザーとチャット選択されたユーザーのIDが等しい時メッセー送信画面に遷移する
-		if(loginUserId == currentUserId || loginUserId == userId) {
+		if (loginUserId == currentUserId || loginUserId == userId) {
 			//チャットルーム1件取得
 			MRoom room = roomService.getRoomOne(id);
 			String roomName = room.getRoomName();
 			model.addAttribute("roomName", roomName);
-			
+
 			//チャットルームに紐づくメッセージ取得
 			List<TMessages> messages = roomService.getMessagesAll(id);
 			model.addAttribute("messages", messages);
-			
+
 			return "messages/index";
 		}
-		
+
+		return "redirect:/";
+	}
+
+	@PostMapping(value = "/rooms/{roomId}/delete", params = "delete")
+	public String deleteRoom(Model model, @AuthenticationPrincipal UserDetailServiceImpll loginUser,
+			@PathVariable("roomId") int id) {
+		//ログインユーザーの情報を取得
+		int loginUserId = loginUser.getUser().getId();
+
+		//room_usersテーブルのレコード(1件)取得
+		TRoomUser roomUser = roomUserService.getRoomUserOne(id);
+
+		//room_usersに登録されているログインユーザーのIDを取得
+		int currentUserId = roomUser.getCurrentUserId();
+		//room_usersに登録されているチャットするユーザーのIDを取得
+		int userId = roomUser.getUserId();
+
+		//ログインユーザーとroom_usersのログインユーザーID、またはログインユーザーとチャット選択されたユーザーのIDが等しい時メッセー送信画面に遷移する
+		if (loginUserId == currentUserId || loginUserId == userId) {
+			roomService.deleteRoomMessageOne(id);
+		}
+
 		return "redirect:/";
 	}
 }

--- a/src/main/java/com/example/demo/controller/RoomController.java
+++ b/src/main/java/com/example/demo/controller/RoomController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.demo.entity.MRoom;
 import com.example.demo.entity.MUser;
+import com.example.demo.entity.TMessages;
 import com.example.demo.entity.TRoomUser;
 import com.example.demo.form.MessageForm;
 import com.example.demo.form.RoomForm;
@@ -108,7 +109,16 @@ public class RoomController {
 		
 		//ログインユーザーとroom_usersのログインユーザーID、またはログインユーザーとチャット選択されたユーザーのIDが等しい時メッセー送信画面に遷移する
 		if(loginUserId == currentUserId || loginUserId == userId) {
-			return "redirect:/rooms/{roomId}";
+			//チャットルーム1件取得
+			MRoom room = roomService.getRoomOne(id);
+			String roomName = room.getRoomName();
+			model.addAttribute("roomName", roomName);
+			
+			//チャットルームに紐づくメッセージ取得
+			List<TMessages> messages = roomService.getMessagesAll(id);
+			model.addAttribute("messages", messages);
+			
+			return "messages/index";
 		}
 		
 		return "redirect:/";

--- a/src/main/java/com/example/demo/entity/MRoom.java
+++ b/src/main/java/com/example/demo/entity/MRoom.java
@@ -17,4 +17,6 @@ public class MRoom {
 	private LocalDateTime createdAt;
 	
 	private List<TRoomUser> roomUserList;
+	
+	private List<TMessages> messagesList;
 }

--- a/src/main/java/com/example/demo/entity/MessagesDetail.java
+++ b/src/main/java/com/example/demo/entity/MessagesDetail.java
@@ -1,0 +1,19 @@
+package com.example.demo.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class MessagesDetail {
+
+	private int id;
+	private String name;
+	private String content;
+	private int roomId;
+	private int userId;
+	private String image;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	
+}

--- a/src/main/java/com/example/demo/entity/TMessages.java
+++ b/src/main/java/com/example/demo/entity/TMessages.java
@@ -13,7 +13,7 @@ public class TMessages {
 	private String content;
 	private int roomId;
 	private int userId;
-	private byte[] image;
+	private String image;
 	
 	@DateTimeFormat(pattern = "yyyy_MM_dd HH:mm:ss")
 	private LocalDateTime createdAt;

--- a/src/main/java/com/example/demo/repository/RoomMapper.java
+++ b/src/main/java/com/example/demo/repository/RoomMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.example.demo.entity.MRoom;
+import com.example.demo.entity.TMessages;
 
 @Mapper
 public interface RoomMapper {
@@ -17,4 +18,7 @@ public interface RoomMapper {
 
 	/**チャットルーム(1件)取得*/
 	public MRoom findRoomOne(int id);
+	
+	/**チャットルームに紐づくメッセージ取得*/
+	public List<TMessages> findMessagesAll(int id);
 }

--- a/src/main/java/com/example/demo/repository/RoomMapper.java
+++ b/src/main/java/com/example/demo/repository/RoomMapper.java
@@ -21,4 +21,7 @@ public interface RoomMapper {
 	
 	/**チャットルームに紐づくメッセージ取得*/
 	public List<TMessages> findMessagesAll(int id);
+	
+	/**チャットルーム(1件)削除*/
+	public int deleteRoomOne(int id);
 }

--- a/src/main/java/com/example/demo/service/RoomService.java
+++ b/src/main/java/com/example/demo/service/RoomService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import com.example.demo.entity.MRoom;
+import com.example.demo.entity.TMessages;
 import com.example.demo.form.RoomForm;
 import com.example.demo.service.impl.UserDetailServiceImpll;
 
@@ -18,5 +19,8 @@ public interface RoomService {
 	
 	/**チャットルーム取得(1件)*/
 	public MRoom getRoomOne(int id);
+	
+	/**チャットルームに紐づくメッセージ取得*/
+	public List<TMessages> getMessagesAll(int id);
 	
 }

--- a/src/main/java/com/example/demo/service/RoomService.java
+++ b/src/main/java/com/example/demo/service/RoomService.java
@@ -23,4 +23,7 @@ public interface RoomService {
 	/**チャットルームに紐づくメッセージ取得*/
 	public List<TMessages> getMessagesAll(int id);
 	
+	/**チャットルーム(1件)削除*/
+	public void deleteRoomMessageOne(int id);
+	
 }

--- a/src/main/java/com/example/demo/service/impl/RoomServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/RoomServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.entity.MRoom;
+import com.example.demo.entity.TMessages;
 import com.example.demo.form.RoomForm;
 import com.example.demo.repository.RoomMapper;
 import com.example.demo.service.RoomService;
@@ -53,6 +54,14 @@ public class RoomServiceImpl implements RoomService {
 	@Override
 	public MRoom getRoomOne(int id) {
 		return mapper.findRoomOne(id);
+	}
+	
+	/**
+	 *チャットルームに紐づくメッセージ取得
+	 */
+	@Override
+	public List<TMessages> getMessagesAll(int id) {
+		return mapper.findMessagesAll(id);
 	}
 
 }

--- a/src/main/java/com/example/demo/service/impl/RoomServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/RoomServiceImpl.java
@@ -63,5 +63,11 @@ public class RoomServiceImpl implements RoomService {
 	public List<TMessages> getMessagesAll(int id) {
 		return mapper.findMessagesAll(id);
 	}
+	
+	@Transactional
+	@Override
+	public void deleteRoomMessageOne(int id) {
+		int count = mapper.deleteRoomOne(id);
+	}
 
 }

--- a/src/main/resources/mapper/RoomMapper.xml
+++ b/src/main/resources/mapper/RoomMapper.xml
@@ -62,6 +62,7 @@
 			ru.current_user_id = #{currentUserId,jdbcType=INTEGER}
 		or 
 			ru.user_id = #{userId,jdbcType=INTEGER}
+		order by r.created_at DESC
 	</select>
 	
 	<!-- チャットルーム1件取得 -->
@@ -91,6 +92,7 @@
 			on m.user_id = u.id
 		where
 			r.id = #{id,jdbcType=INTEGER}
+		order by m.created_at DESC
 	</select>
 	
 	<!-- チャットルーム削除(1件) -->

--- a/src/main/resources/mapper/RoomMapper.xml
+++ b/src/main/resources/mapper/RoomMapper.xml
@@ -10,6 +10,7 @@
 		<result column="room_name" property="roomName"></result>
 		<result column="created_at" property="createdAt"></result>
 		<collection property="roomUserList" resultMap="roomUser"></collection>
+		<collection property="messagesList" resultMap="message"></collection>
 	</resultMap>
 	
 	<!-- マッピング定義(room_user) -->
@@ -19,6 +20,17 @@
 		<result column="current_user_id" property="currentUserId"></result>
 		<result column="created_at" property="createdAt"></result>
 		<result column="user_id" property="userId"></result>
+	</resultMap>
+	
+	<!-- マッピング定義(messages) -->
+	<resultMap type="com.example.demo.entity.TMessages" id="message">
+		<id column="id" property="id"></id>
+		<result column="content" property="content"></result>
+		<result column="image" property="image"></result> 
+		<result column="room_id" property="roomId"></result>
+		<result column="user_id" property="userId"></result>
+		<result column="created_at" property="createdAt"></result>
+		<result column="updated_at" property="updatedAt"></result>
 	</resultMap>
 	
 	<!-- チャットルーム登録 -->
@@ -59,6 +71,26 @@
 		from rooms
 		where 
 			id = #{id,jdbcType=INTEGER}
+	</select>
+	
+	<!-- チャットルームに紐づくメッセージ取得 -->
+	<select id="findMessagesAll" resultType="com.example.demo.entity.MessagesDetail">
+		select
+			u.name,
+			m.id,
+			content,
+			image,
+			m.room_id,
+			m.user_id,
+			m.created_at,
+			m.updated_at
+		from rooms r
+		inner join messages m
+			on r.id = m.room_id
+		inner join users u
+			on m.user_id = u.id
+		where
+			r.id = #{id,jdbcType=INTEGER}
 	</select>
 	
 </mapper>

--- a/src/main/resources/mapper/RoomMapper.xml
+++ b/src/main/resources/mapper/RoomMapper.xml
@@ -93,4 +93,12 @@
 			r.id = #{id,jdbcType=INTEGER}
 	</select>
 	
+	<!-- チャットルーム削除(1件) -->
+	<delete id="deleteRoomOne">
+		delete
+			from rooms
+		where
+			id = #{id,jdbcType=INTEGER}
+	</delete>
+	
 </mapper>

--- a/src/main/resources/static/css/messages/messages.css
+++ b/src/main/resources/static/css/messages/messages.css
@@ -73,35 +73,7 @@
 }
 
 .header-button {
-	margin-top: 40px;
-}
-
-.header-button a {
-	color: darkred;
-	border: 1px solid darkred;
-	text-decoration: none;
-	padding: 20px;
-}
-
-.search {
-	display: flex;
-	flex-direction: column;
-	margin: 20px 0;
-}
-
-.search-form {
-	width: 100%;
-	height: 30px;
-	border: 1px solid gray;
-}
-
-.search-btn {
-	margin: 5px auto;
-	width: 50%;
-	color: white;
-	background-color: #38AEF0;
-	border: none;
-	padding: 5px;
+	margin-top: 20px;
 }
 
 .messages {
@@ -187,4 +159,13 @@
 .message-image {
 	height: 500px;
 	width: 500px;
+}
+
+.delete-btn {
+	cursor: pointer;
+	border: 1px solid darkred;
+	color: darkred;
+	background-color: white;
+	font-size: 17px;
+	padding: 20px 25px;
 }

--- a/src/main/resources/static/css/messages/messages.css
+++ b/src/main/resources/static/css/messages/messages.css
@@ -183,3 +183,8 @@
 .hidden {
 	display: none;
 }
+
+.message-image {
+	height: 500px;
+	width: 500px;
+}

--- a/src/main/resources/templates/layout/main_chat.html
+++ b/src/main/resources/templates/layout/main_chat.html
@@ -9,7 +9,7 @@
 	<div class="chat" layout:fragment="main_chat">
 		<div class="chat-header">
 			<div class="left-header">
-				<div class="header-title">hogefuga</div>
+				<div class="header-title" th:text="${roomName}"></div>
 			</div>
 			<div class="right-header">
 				<div class="header-button">
@@ -19,23 +19,16 @@
 		</div>
 
 		<div class="messages">
-			<div class="message">
+			<div class="message" th:each="message: ${messages}">
 				<div class="upper-message">
-					<div class="message-user">Tom</div>
-					<div class="message-date">2020/3/31(Wed) 12:43:30</div>
+					<div class="message-user" th:text="${message.name}"></div>
+					<div class="message-date" th:text="${message.createdAt}">></div>
 				</div>
 				<div class="lower-message">
-					<div class="message-content">おはよう</div>
-				</div>
-			</div>
-
-			<div class="message">
-				<div class="upper-message">
-					<div class="message-user">Tom</div>
-					<div class="message-date">2020/3/31(Wed) 12:47:30</div>
-				</div>
-				<div class="lower-message">
-					<div class="message-content">こんばんは</div>
+					<div class="message-content" th:text="${message.content}"></div>
+					<div th:if="${message.image != 'data:image/png;base64, '}">
+						<img class="message-image" th:src="${message.image}" alt="">
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/main/resources/templates/layout/main_chat.html
+++ b/src/main/resources/templates/layout/main_chat.html
@@ -12,9 +12,9 @@
 				<div class="header-title" th:text="${roomName}"></div>
 			</div>
 			<div class="right-header">
-				<div class="header-button">
-					<a href="#">チャットを終了する</a>
-				</div>
+				<form th:action="@{'/rooms/'+${roomId}+'/delete'}" method="post" class="header-button">
+					<input class="delete-btn" name="delete" type="submit" value="チャットを終了する">
+				</form>
 			</div>
 		</div>
 

--- a/src/main/resources/templates/layout/main_chat.html
+++ b/src/main/resources/templates/layout/main_chat.html
@@ -26,9 +26,7 @@
 				</div>
 				<div class="lower-message">
 					<div class="message-content" th:text="${message.content}"></div>
-					<div th:if="${message.image != 'data:image/png;base64, '}">
-						<img class="message-image" th:src="${message.image}" alt="">
-					</div>
+					<img th:if="${message.image != 'data:image/png;base64, '}" class="message-image" th:src="${message.image}" alt="">
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
#What
- メッセージ・画像一覧表示機能の実装
- チャットルーム削除機能の実装

#Why
3テーブルを結合して、3つのテーブルに存在する値を取得する方法を理解するため。
また、画像表示(.png、.jpeg等)の実装方法、それに付随する画像保存の方法を理解するため、

詳細画面遷移のロジック同様に削除を特定のユーザーのみに許可するようにするため。